### PR TITLE
Feature/update api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,10 +10,6 @@ import (
 	"github.com/ONSdigital/go-ns/rhttp"
 )
 
-var (
-	maxRetries = 5
-)
-
 func callAPI(
 	client *rhttp.Client,
 	method, path, authToken string,

--- a/api/import_api.go
+++ b/api/import_api.go
@@ -19,14 +19,18 @@ type ImportAPI struct {
 
 // ImportJob comes from the Import API and links an import job to its (other) instances
 type ImportJob struct {
-	JobID     string         `json:"job_id"`
+	JobID string  `json:"id"`
+	Links LinkMap `json:"links,ignoreempty"`
+}
+
+type LinkMap struct {
 	Instances []InstanceLink `json:"instances"`
 }
 
 // InstanceLink identifies an (instance or import-job) by id and url (from Import API)
 type InstanceLink struct {
 	ID   string `json:"id"`
-	Link string `json:"link"`
+	Link string `json:"href"`
 }
 
 // NewImportAPI creates an ImportAPI object
@@ -69,7 +73,7 @@ func (api *ImportAPI) GetImportJob(importJobID string) (ImportJob, error) {
 func (api *ImportAPI) UpdateImportJobState(jobID string, newState string) error {
 	path := api.url + "/jobs/" + jobID
 	logData := log.Data{"url": path}
-	jsonUpload := []byte(`{"job_id":"` + jobID + `","state":"` + newState + `"}`)
+	jsonUpload := []byte(`{"state":"` + newState + `"}`)
 	logData["jsonUpload"] = jsonUpload
 	jsonResult, httpCode, err := api.put(path, 0, jsonUpload)
 	logData["httpCode"] = httpCode

--- a/api/import_api.go
+++ b/api/import_api.go
@@ -3,14 +3,16 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"github.com/ONSdigital/go-ns/log"
 	"net/http"
 	"net/url"
+
+	"github.com/ONSdigital/go-ns/log"
+	"github.com/ONSdigital/go-ns/rhttp"
 )
 
 // ImportAPI aggregates a client and url and other common data for accessing the API
 type ImportAPI struct {
-	client    *http.Client
+	client    *rhttp.Client
 	url       string
 	authToken string
 }
@@ -28,7 +30,7 @@ type InstanceLink struct {
 }
 
 // NewImportAPI creates an ImportAPI object
-func NewImportAPI(client *http.Client, url, authToken string) *ImportAPI {
+func NewImportAPI(client *rhttp.Client, url, authToken string) *ImportAPI {
 	return &ImportAPI{
 		client:    client,
 		url:       url,
@@ -83,9 +85,9 @@ func (api *ImportAPI) UpdateImportJobState(jobID string, newState string) error 
 }
 
 func (api *ImportAPI) get(path string, attempts int, vars url.Values) ([]byte, int, error) {
-	return callAPI(api.client, "GET", path, api.authToken, maxRetries, attempts, vars)
+	return callAPI(api.client, "GET", path, api.authToken, vars)
 }
 
 func (api *ImportAPI) put(path string, attempts int, payload []byte) ([]byte, int, error) {
-	return callAPI(api.client, "PUT", path, api.authToken, maxRetries, attempts, payload)
+	return callAPI(api.client, "PUT", path, api.authToken, payload)
 }

--- a/api/import_api_test.go
+++ b/api/import_api_test.go
@@ -6,11 +6,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/go-ns/rhttp"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (
-	client = &http.Client{}
+	client = &rhttp.Client{HTTPClient: &http.Client{}}
 )
 
 type MockedHTTPResponse struct {

--- a/api/import_api_test.go
+++ b/api/import_api_test.go
@@ -34,8 +34,8 @@ func getMockImportAPI(expectRequest http.Request, mockedHTTPResponse MockedHTTPR
 
 func TestGetImportJob(t *testing.T) {
 	jobID := "jid1"
-	jobJSON := `{"job_id":"` + jobID + `","instances":[{"id":"iid1","link":"iid1link"}]}`
-	jobMultiInstJSON := `{"job_id":"` + jobID + `","instances":[{"id":"iid1","link":"iid1link"},{"id":"iid2","link":"iid2link"}]}`
+	jobJSON := `{"id":"` + jobID + `","links":{"instances":[{"id":"iid1","href":"iid1link"}]}}`
+	jobMultiInstJSON := `{"id":"` + jobID + `","links":{"instances":[{"id":"iid1","href":"iid1link"},{"id":"iid2","href":"iid2link"}]}}`
 
 	Convey("When no import-job is returned", t, func() {
 		mockedAPI := getMockImportAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 404, Body: ""})
@@ -60,17 +60,22 @@ func TestGetImportJob(t *testing.T) {
 		mockedAPI := getMockImportAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: jobJSON})
 		job, err := mockedAPI.GetImportJob(jobID)
 		So(err, ShouldBeNil)
-		So(job, ShouldResemble, ImportJob{JobID: jobID, Instances: []InstanceLink{InstanceLink{ID: "iid1", Link: "iid1link"}}})
+		So(job, ShouldResemble, ImportJob{JobID: jobID, Links: LinkMap{Instances: []InstanceLink{InstanceLink{ID: "iid1", Link: "iid1link"}}}})
 	})
 
 	Convey("When a multiple-instance import-job is returned", t, func() {
 		mockedAPI := getMockImportAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: jobMultiInstJSON})
 		job, err := mockedAPI.GetImportJob(jobID)
 		So(err, ShouldBeNil)
-		So(job, ShouldResemble, ImportJob{JobID: jobID, Instances: []InstanceLink{
-			InstanceLink{ID: "iid1", Link: "iid1link"},
-			InstanceLink{ID: "iid2", Link: "iid2link"},
-		}})
+		So(job, ShouldResemble, ImportJob{
+			JobID: jobID,
+			Links: LinkMap{
+				Instances: []InstanceLink{
+					InstanceLink{ID: "iid1", Link: "iid1link"},
+					InstanceLink{ID: "iid2", Link: "iid2link"},
+				},
+			},
+		})
 	})
 }
 

--- a/cmd/dp-import-tracker/main.go
+++ b/cmd/dp-import-tracker/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"net/http"
 	"net/url"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/ONSdigital/dp-import-tracker/schema"
 	"github.com/ONSdigital/go-ns/kafka"
 	"github.com/ONSdigital/go-ns/log"
+	"github.com/ONSdigital/go-ns/rhttp"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -226,7 +226,7 @@ func main() {
 		logFatal("could not obtain consumer", err, log.Data{"topic": cfg.ObservationsInsertedTopic})
 	}
 
-	client := &http.Client{}
+	client := rhttp.DefaultClient
 	importAPI := api.NewImportAPI(client, cfg.ImportAPIAddr, cfg.ImportAPIAuthToken)
 	datasetAPI := api.NewDatasetAPI(client, cfg.DatasetAPIAddr, cfg.DatasetAPIAuthToken)
 

--- a/cmd/dp-import-tracker/main.go
+++ b/cmd/dp-import-tracker/main.go
@@ -73,7 +73,7 @@ func (trackedInstances trackedInstanceList) updateInstanceFromDatasetAPI(dataset
 
 // getInstanceList gets a list of current import Instances, to seed our in-memory list
 func (trackedInstances trackedInstanceList) getInstanceList(api *api.DatasetAPI) error {
-	instancesFromAPI, err := api.GetInstances(url.Values{"instance_states": []string{"created"}})
+	instancesFromAPI, err := api.GetInstances(url.Values{"state": []string{"submitted"}})
 	if err != nil {
 		return err
 	}
@@ -101,8 +101,8 @@ func CheckImportJobCompletionState(importAPI *api.ImportAPI, datasetAPI *api.Dat
 	}
 
 	targetState := "completed"
-	log.Debug("checking", log.Data{"API insts": importJobFromAPI.Instances})
-	for _, instanceRef := range importJobFromAPI.Instances {
+	log.Debug("checking", log.Data{"API insts": importJobFromAPI.Links.Instances})
+	for _, instanceRef := range importJobFromAPI.Links.Instances {
 		if instanceRef.ID == completedInstanceID {
 			continue
 		}

--- a/vendor/github.com/ONSdigital/go-ns/rhttp/README.md
+++ b/vendor/github.com/ONSdigital/go-ns/rhttp/README.md
@@ -1,0 +1,57 @@
+# rhttp
+
+rhttp stands for robust HTTP, and provides a default client which inherits the
+methods associated with the standard HTTP client, but with the addition of
+production ready timeouts, and the ability to perform exponential backoff when
+calling another HTTP server.
+
+### How to use
+
+rhttp should have a familiar feel to it when it is used - with an example given
+below:
+
+```go
+import github.com/ONSdigital/go-ns/rhttp
+
+func main() {
+    cli := rhttp.DefaultClient
+
+    resp, err := cli.Get("https://www.google.com")
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+}
+```
+
+In this case, in the unlikely event of https://www.google.com returning a status
+of 500 or above, the client will retry at exponentially increasing intervals, until
+the max retries (10 by default is reached).
+
+You also do not have to use the default client if you don't like the configured 
+timeouts or do not wish to use exponential backoff. The following example shows
+how to configure your own rhttp client:
+
+```go
+import github.com/ONSdigital/go-ns/rhttp
+
+func main() {
+    cli := &rhttp.Client{
+        MaxRetries:         10, // The maximum number of retries you wish to wait for
+        ExponentialBackoff: true, // Set to false if you do not want exponential backoff
+        RetryTime:          1 * time.Second, // The time between the first set of retries
+
+        HTTPClient: &http.Client{ // Create your own http client with configured timeouts
+            Timeout: 10 * time.Second,
+            Transport: &http.Transport{
+                Dial: (&net.Dialer{
+                    Timeout: 5 * time.Second,
+                }).Dial,
+                TLSHandshakeTimeout: 5 * time.Second,
+                MaxIdleConns:        10,
+                IdleConnTimeout:     30 * time.Second,
+            },
+        },
+    }
+}
+```

--- a/vendor/github.com/ONSdigital/go-ns/rhttp/client.go
+++ b/vendor/github.com/ONSdigital/go-ns/rhttp/client.go
@@ -1,0 +1,176 @@
+package rhttp
+
+import (
+	"io"
+	"math"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client is an extension of the net/http client with ability to add
+// timeouts and exponential backoff
+type Client struct {
+	MaxRetries         int
+	ExponentialBackoff bool
+	RetryTime          time.Duration
+
+	HTTPClient *http.Client
+}
+
+// DefaultClient is a go-ns specific http client with sensible timeouts
+// and exponential backoff
+var DefaultClient = &Client{
+	MaxRetries:         10,
+	ExponentialBackoff: true,
+	RetryTime:          20 * time.Millisecond,
+
+	HTTPClient: &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 5 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 5 * time.Second,
+			MaxIdleConns:        10,
+			IdleConnTimeout:     30 * time.Second,
+		},
+	},
+}
+
+// Do calls net/http Do with the addition of exponential backoff
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	do := func(args ...interface{}) (*http.Response, error) {
+		return c.HTTPClient.Do(args[0].(*http.Request))
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		if c.ExponentialBackoff {
+			return c.backoff(do, req)
+		}
+		return nil, err
+	}
+
+	if resp.StatusCode >= http.StatusInternalServerError && c.ExponentialBackoff {
+		return c.backoff(do, req)
+	}
+
+	return resp, err
+}
+
+// Get calls net/http Get with the addition of exponential backoff
+func (c *Client) Get(url string) (*http.Response, error) {
+	get := func(args ...interface{}) (*http.Response, error) {
+		return c.HTTPClient.Get(args[0].(string))
+	}
+
+	resp, err := c.HTTPClient.Get(url)
+	if err != nil {
+		if c.ExponentialBackoff {
+			return c.backoff(get, url)
+		}
+		return nil, err
+	}
+
+	if resp.StatusCode >= http.StatusInternalServerError && c.ExponentialBackoff {
+		return c.backoff(get, url)
+	}
+
+	return resp, err
+}
+
+// Head calls net/http Head with the addition of exponential backoff
+func (c *Client) Head(url string) (*http.Response, error) {
+	head := func(args ...interface{}) (*http.Response, error) {
+		return c.HTTPClient.Head(args[0].(string))
+	}
+
+	resp, err := c.HTTPClient.Head(url)
+	if err != nil {
+		if c.ExponentialBackoff {
+			return c.backoff(head, url)
+		}
+		return nil, err
+	}
+
+	if resp.StatusCode >= http.StatusInternalServerError && c.ExponentialBackoff {
+		return c.backoff(head, url)
+	}
+
+	return resp, err
+}
+
+// Post calls net/http Post with the addition of exponential backoff
+func (c *Client) Post(url string, contentType string, body io.Reader) (*http.Response, error) {
+	post := func(args ...interface{}) (*http.Response, error) {
+		return c.HTTPClient.Post(args[0].(string), args[1].(string), args[2].(io.Reader))
+	}
+
+	resp, err := c.HTTPClient.Post(url, contentType, body)
+	if err != nil {
+		if c.ExponentialBackoff {
+			return c.backoff(post, url, contentType, body)
+		}
+		return nil, err
+	}
+
+	if resp.StatusCode >= http.StatusInternalServerError && c.ExponentialBackoff {
+		return c.backoff(post, url, contentType, body)
+	}
+
+	return resp, err
+}
+
+// PostForm calls net/http PostForm with the addition of exponential backoff
+func (c *Client) PostForm(uri string, data url.Values) (*http.Response, error) {
+	postForm := func(args ...interface{}) (*http.Response, error) {
+		return c.HTTPClient.PostForm(args[0].(string), args[1].(url.Values))
+	}
+
+	resp, err := c.HTTPClient.PostForm(uri, data)
+	if err != nil {
+		if c.ExponentialBackoff {
+			return c.backoff(postForm, uri, data)
+		}
+		return nil, err
+	}
+
+	if resp.StatusCode >= http.StatusInternalServerError && c.ExponentialBackoff {
+		return c.backoff(postForm, uri, data)
+	}
+
+	return resp, err
+}
+
+func (c *Client) backoff(f func(...interface{}) (*http.Response, error), args ...interface{}) (resp *http.Response, err error) {
+	for attempt := 1; attempt <= c.MaxRetries; attempt++ {
+		sleepTime := getSleepTime(attempt, c.RetryTime)
+
+		time.Sleep(sleepTime)
+
+		resp, err = f(args...)
+		if err != nil || resp.StatusCode >= http.StatusInternalServerError {
+			if attempt == c.MaxRetries {
+				return
+			}
+			continue
+		}
+
+		return
+	}
+	return
+}
+
+// getSleepTime will return a sleep time based on the attempt and initial retry time.
+// It uses the algorithm 2^n where n is the attempt number (double the previous) and
+// a randomization factor of between 0-5ms so that the server isn't being hit constantly
+// at the same time by many clients
+func getSleepTime(attempt int, retryTime time.Duration) time.Duration {
+	n := (math.Pow(2, float64(attempt)))
+	rand.Seed(time.Now().Unix())
+	rnd := time.Duration(rand.Intn(4)+1) * time.Millisecond
+	return (time.Duration(n) * retryTime) - rnd
+}


### PR DESCRIPTION
update to the new API spec (re `id` over `job_id`, and `links.instances.href` over `instances.link`)
also switches to `go-ns/rhttp` client