### PR TITLE
Feature/insert count from db

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for the parent import job, if all other instances are also `completed`).
 | IMPORT_API_AUTH_TOKEN                 | _no default_                                  | Authentication token for access to import API
 | DATASET_API_ADDR                      | `http://localhost:22000`                      | The address of Dataset API
 | DATASET_API_AUTH_TOKEN                | _no default_                                  | Authentication token for access to Dataset API
-| DB_ACCESS                             | `user=dp dbname=ImportJobs sslmode=disable`   | URL for Postgresql
+| DATABASE_ADDRESS                      | `bolt://localhost:7687`                       | The address of the database
 
 ### Contributing
 

--- a/store/neo4j.go
+++ b/store/neo4j.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
+)
+
+const countObservationsStmt = "MATCH (o:`_%s_observation`) RETURN COUNT(o)"
+
+func CountInsertedObservations(dbConn bolt.Conn, instanceID string) (count int64, err error) {
+	var rowCursor bolt.Rows
+	if rowCursor, err = dbConn.QueryNeo(fmt.Sprintf(countObservationsStmt, instanceID), nil); err != nil {
+		return
+	}
+	defer rowCursor.Close()
+	rows, _, err := rowCursor.All()
+	if err != nil {
+		return
+	}
+	var ok bool
+	if count, ok = rows[0][0].(int64); !ok {
+		return -1, errors.New("Did not get result from DB")
+	}
+	return
+}


### PR DESCRIPTION
### What

when 
       (a) the dataset-api count of inserted observations (from kafka messages)
 reaches (at least) 
       (b) the expected total of observations
we now check the database directly for the count of observations (just in case kafka has sent us number-of-inserts messages more than once, over-inflating (a) above)
