### PR TITLE
Use updated kafka lib with indefinite offset retention.

### DIFF
--- a/cmd/dp-import-tracker/main.go
+++ b/cmd/dp-import-tracker/main.go
@@ -382,7 +382,7 @@ func main() {
 		cfg.Brokers,
 		cfg.NewInstanceTopic,
 		cfg.NewInstanceConsumerGroup,
-		kafka.OffsetOldest)
+		kafka.OffsetNewest)
 	if err != nil {
 		logFatal("could not obtain consumer", err, log.Data{"topic": cfg.NewInstanceTopic})
 	}
@@ -391,7 +391,7 @@ func main() {
 		cfg.Brokers,
 		cfg.ObservationsInsertedTopic,
 		cfg.ObservationsInsertedConsumerGroup,
-		kafka.OffsetOldest)
+		kafka.OffsetNewest)
 	if err != nil {
 		logFatal("could not obtain consumer", err, log.Data{"topic": cfg.ObservationsInsertedTopic})
 	}
@@ -400,7 +400,7 @@ func main() {
 		cfg.Brokers,
 		cfg.HierarchyBuiltTopic,
 		cfg.HierarchyBuiltConsumerGroup,
-		kafka.OffsetOldest)
+		kafka.OffsetNewest)
 	if err != nil {
 		logFatal("could not obtain consumer", err, log.Data{"topic": cfg.HierarchyBuiltTopic})
 	}

--- a/vendor/github.com/ONSdigital/go-ns/kafka/consumer-group.go
+++ b/vendor/github.com/ONSdigital/go-ns/kafka/consumer-group.go
@@ -117,8 +117,9 @@ func newConsumer(brokers []string, topic string, group string, offset int64, syn
 	config.Consumer.Return.Errors = true
 	config.Consumer.MaxWaitTime = 50 * time.Millisecond
 	config.Consumer.Offsets.Initial = offset
+	config.Consumer.Offsets.Retention = 0 // indefinite retention
 
-	logData := log.Data{"topic": topic, "group": group}
+	logData := log.Data{"topic": topic, "group": group, "config": config}
 
 	consumer, err := cluster.NewConsumer(brokers, group, []string{topic}, config)
 	if err != nil {
@@ -149,7 +150,7 @@ func newConsumer(brokers []string, topic string, group string, offset int64, syn
 	// listener goroutine - listen to consumer.Messages() and upstream them
 	// if this blocks while upstreaming a message, we can shutdown consumer via the following goroutine
 	go func() {
-		logData := log.Data{"topic": topic, "group": group}
+		logData := log.Data{"topic": topic, "group": group, "config": config}
 
 		log.Info("Started kafka consumer listener", logData)
 		defer close(cg.closed)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,10 +21,10 @@
 			"revisionTime": "2017-12-08T11:11:03Z"
 		},
 		{
-			"checksumSHA1": "lUqiCTOoWg3IhyenCyYvqbw64OE=",
+			"checksumSHA1": "qqaN4hllMTNueffB5bcz8xQnwX0=",
 			"path": "github.com/ONSdigital/go-ns/kafka",
-			"revision": "c45be7d1a146fdaf45f65304f09c7952a9aaf2cb",
-			"revisionTime": "2017-12-08T11:11:03Z"
+			"revision": "b7a9d79bc028131d34399e7ef420b73007786202",
+			"revisionTime": "2018-01-23T16:28:19Z"
 		},
 		{
 			"checksumSHA1": "AjbjbhFVAOP/1NU5HL+uy+X/yJo=",


### PR DESCRIPTION
### What

Pessimistically use kafka.OffsetNewest as the initial offset until we
are confident that the issue is entirely fixed. The worst case scenario
using OffsetNewest is lost messages. For the import process this means
trying the import again. The worst case when using OffsetOldest is
replaying messages and making data inconsistent. We should consider
changing all services to use kafka.OffsetOldest when the issue is fixed, 
so that no messages are lost when the service first starts.

### How to review

Review changes.

### Who can review

Anyone
