### PR TITLE
Improve service logging

### DIFF
--- a/cmd/dp-import-tracker/main.go
+++ b/cmd/dp-import-tracker/main.go
@@ -357,10 +357,9 @@ func manageActiveInstanceEvents(
 			instanceID := updateObservationsInserted.InstanceID
 			observationsInserted := updateObservationsInserted.NumberOfObservationsInserted
 			logData := log.Data{"instance_id": instanceID, "observations_inserted": observationsInserted}
-			if _, ok := trackedInstances[instanceID]; !ok {
+			if ti, ok := trackedInstances[instanceID]; !ok {
 				log.Info("warning: import instance not in tracked list for update", logData)
-			}
-			if ti, ok := trackedInstances[instanceID]; ok {
+			} else {
 				if !ti.begunObservationInsertUpdate {
 					log.Info("updating number of observations inserted for instance", log.Data{"instance_id": instanceID})
 					ti.begunObservationInsertUpdate = true

--- a/vendor/github.com/ONSdigital/go-ns/common/identity.go
+++ b/vendor/github.com/ONSdigital/go-ns/common/identity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -153,12 +154,15 @@ func AddRequestIdHeader(r *http.Request, token string) {
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 var requestIDRandom = rand.New(rand.NewSource(time.Now().UnixNano()))
+var randMutex sync.Mutex
 
 // NewRequestID generates a random string of requested length
 func NewRequestID(size int) string {
 	b := make([]rune, size)
+	randMutex.Lock()
 	for i := range b {
 		b[i] = letters[requestIDRandom.Intn(len(letters))]
 	}
+	randMutex.Unlock()
 	return string(b)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,10 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "l4G8sAoDnulKL5r5EEK/hMe90WI=",
+			"checksumSHA1": "8GX4z3tt4e6rXHJtJv8q8YZrFwk=",
 			"path": "github.com/ONSdigital/go-ns/common",
-			"revision": "491470a66fbb2471ff3fd02f8159b7158d9281ab",
-			"revisionTime": "2018-06-07T13:26:14Z"
+			"revision": "40bd7a2162e3296b504c5540899bb3a13ef15936",
+			"revisionTime": "2018-06-21T10:26:04Z"
 		},
 		{
 			"checksumSHA1": "Vjyl/gfY0qx2lW9te3Ieb5HV3/s=",


### PR DESCRIPTION
### What

Improve logging to ensure that service is not spammed by unreadable logs

- Log when an instance is added to the tracker
- Do not log every time that tracker pings dataset api (it will log on failure anyway)
- Only log once when updating an instance on dataset api with number of observations inserted
- Log more sensibly when updating import api job state

### How to review

Run locally and verify logs are sensible

### Who can review

Anyone