### PR TITLE
Release 1.12.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 Office for National Statistics
+Copyright (c) 2016-2021 Office for National Statistics
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | IMPORT_OBSERVATIONS_INSERTED_CONSUMER_GROUP | dp-import-tracker                     | consumer group name for numbers of inserted observations
 | HIERARCHY_BUILT_TOPIC                       | hierarchy-built                       | topic name for built hierarchies
 | HIERARCHY_BUILT_CONSUMER_GROUP              | dp-import-tracker                     | consumer group name for built hierarchies
-| SEARCH_BUILT_TOPIC                          | search-built                          | topic name for search built
+| SEARCH_BUILT_TOPIC                          | dimension-search-built                | topic name for search built
 | SEARCH_BUILT_CONSUMER_GROUP                 | dp-import-tracker                     | consumer group name for search built
 | DATA_IMPORT_COMPLETE_TOPIC                  | data-import-complete                  | topic name for hierarchies ready to be imported
 | KAFKA_ADDR                                  | localhost:9092                        | A list of kafka brokers
@@ -63,6 +63,6 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### License
 
-Copyright © 2016-2017, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2016-2021, Office for National Statistics (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.8
+    tag: 1.16.3
 
 inputs:
   - name: dp-import-tracker

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.8
+    tag: 1.16.3
 
 inputs:
   - name: dp-import-tracker

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ func NewConfig() (*Config, error) {
 		ObservationsInsertedConsumerGroup: "dp-import-tracker",
 		HierarchyBuiltTopic:               "hierarchy-built",
 		HierarchyBuiltConsumerGroup:       "dp-import-tracker",
-		SearchBuiltTopic:                  "search-built",
+		SearchBuiltTopic:                  "dimension-search-built",
 		SearchBuiltConsumerGroup:          "dp-import-tracker",
 		DataImportCompleteTopic:           "data-import-complete",
 		Brokers:                           []string{"localhost:9092"},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-import-tracker
 
-go 1.15
+go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.30.0
@@ -11,6 +11,7 @@ require (
 	github.com/ONSdigital/dp-kafka/v2 v2.1.1
 	github.com/ONSdigital/dp-net v1.0.9
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad // indirect
+	github.com/ONSdigital/gremgo-neptune v1.0.0 // indirect
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=


### PR DESCRIPTION
### What

Release branch containing…

- Rename `dimension-search-built` kafka topic
- Upgrade go to 1.16.3

NB. This needs to be released after the [dp-dimension-search-builder](https://github.com/ONSdigital/dp-dimension-search-builder) v1.8.0

### How to review

Ensure only the expected commits are in the PR and the tests pass

### Who can review

Anyone but me